### PR TITLE
Letter capitalization fixed in the readme.md file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,7 @@ for installing you can using Git or Clone this project into your local machine.
 	3. Copy this project to "htdocs" folder (every local web server have different folder name).
 	4. Done.
 
-And how to configure this website? follow this step clearly:
+And how to configure this website? Follow this step clearly:
 
 	1. Open "darkblow_config.json".
 	2. Setup your credentials server.


### PR DESCRIPTION
Hello! I was looking for some open source projects to contribute to, and I've found this project.
I've read the readme, and found out there was a minor capitalization mistake.

The sentence "follow this step clearly" used a non-capital letter as the first letter. The sentence before "follow this step clearly" ended, so "follow this step clearly" has been changed to include a capital letter at the beginning.